### PR TITLE
remove uneeded animated parameter

### DIFF
--- a/Classes/UINavigationController+STPTransitions.h
+++ b/Classes/UINavigationController+STPTransitions.h
@@ -5,11 +5,9 @@
 @interface UINavigationController (STPTransitions)
 
 - (void)pushViewController:(UIViewController *)viewController
-                  animated:(BOOL)animated
            usingTransition:(STPTransition *)transition;
 
-- (UIViewController *)popViewControllerAnimated:(BOOL)animated
-                                usingTransition:(STPTransition *)transition;
+- (UIViewController *)popViewControllerUsingTransition:(STPTransition *)transition;
 
 
 @end

--- a/Classes/UINavigationController+STPTransitions.m
+++ b/Classes/UINavigationController+STPTransitions.m
@@ -5,16 +5,14 @@
 @implementation UINavigationController (STPTransitions)
 
 - (void)pushViewController:(UIViewController *)viewController
-                  animated:(BOOL)animated
            usingTransition:(STPTransition *)transition {
     [STPTransitionCenter sharedInstance].nextTransition = transition;
-    [self pushViewController:viewController animated:animated];
+    [self pushViewController:viewController animated:YES];
 }
 
-- (UIViewController *)popViewControllerAnimated:(BOOL)animated
-                                usingTransition:(STPTransition *)transition {
+- (UIViewController *)popViewControllerUsingTransition:(STPTransition *)transition {
     [STPTransitionCenter sharedInstance].nextTransition = transition;
-    return [self popViewControllerAnimated:animated];
+    return [self popViewControllerAnimated:YES];
 }
 
 @end


### PR DESCRIPTION
Since the user is supplying an animation transition for
the operation, it can safely be assumed that the user wants
the transition to be animated.
