### PR TITLE
Use UIPresentationController controller for iOS8 SDK support and only apply rotation fix on iOS7 devices

### DIFF
--- a/Core/STPPresentationController.h
+++ b/Core/STPPresentationController.h
@@ -1,0 +1,3 @@
+@interface STPPresentationController : UIPresentationController
+
+@end

--- a/Core/STPPresentationController.m
+++ b/Core/STPPresentationController.m
@@ -1,0 +1,9 @@
+#import "STPPresentationController.h"
+
+@implementation STPPresentationController
+
+- (BOOL)shouldRemovePresentersView {
+    return YES;
+}
+
+@end

--- a/Core/STPTransitionCenter.m
+++ b/Core/STPTransitionCenter.m
@@ -1,5 +1,6 @@
 #import "STPTransitionCenter.h"
 
+#import "STPPresentationController.h"
 #import "STPTransition.h"
 #import "UIViewController+STPTransitions.h"
 
@@ -104,6 +105,12 @@ typedef NS_ENUM(NSUInteger, STPTransitionOperation) {
 
 - (id<UIViewControllerInteractiveTransitioning>)interactionControllerForDismissal:(id<UIViewControllerAnimatedTransitioning>)animator {
     return [self interactorForAnimator:animator];
+}
+
+- (UIPresentationController *)presentationControllerForPresentedViewController:(UIViewController *)presented
+                                                      presentingViewController:(UIViewController *)presenting
+                                                          sourceViewController:(UIViewController *)source {
+    return [[STPPresentationController alloc] initWithPresentedViewController:presented presentingViewController:presenting];
 }
 
 #pragma mark - Internal Methods

--- a/Core/UIViewController+STPTransitions.m
+++ b/Core/UIViewController+STPTransitions.m
@@ -119,8 +119,12 @@
     viewControllerToPresent.sourceViewController = self;
     viewControllerToPresent.modalPresentationStyle = UIModalPresentationCustom;
     viewControllerToPresent.transitioningDelegate = center;
-    transition.needsRotationFixForModals = YES;
-    transition.reverseTransition.needsRotationFixForModals = YES;
+
+    if (self.isUsingIOS7) {
+        transition.needsRotationFixForModals = YES;
+        transition.reverseTransition.needsRotationFixForModals = YES;
+    }
+
     [self presentViewController:viewControllerToPresent animated:YES completion:completion];
 }
 
@@ -188,6 +192,20 @@
         self.view.frame = self.view.superview.bounds;
         self.view.transform = CGAffineTransformIdentity;
     }
+}
+
+#pragma mark - Internal Methods
+
+- (BOOL)isUsingIOS7 {
+    BOOL result = NO;
+    NSArray *decomposedOSVersion = [[UIDevice currentDevice].systemVersion componentsSeparatedByString:@"."];
+    NSUInteger majorIOSVersion = [decomposedOSVersion.firstObject integerValue];
+
+    if (majorIOSVersion == 7) {
+        result = YES;
+    }
+
+    return result;
 }
 
 @end


### PR DESCRIPTION
When using the iOS8 SDK, the `UIModalPresentationCustom` presentation style requires a custom `UIPresentationController` to be used for the view that will be transitioned to for the view to be added on to the view hierarchy after the transition.

From the iOS8 SDK [documentation](https://developer.apple.com/library/prerelease/ios/documentation/UIKit/Reference/UIViewControllerTransitioningDelegate_protocol/index.html#//apple_ref/occ/intfm/UIViewControllerTransitioningDelegate/presentationControllerForPresentedViewController:presentingViewController:sourceViewController:) for the `UIViewControllerTransitioningDelegate` `presentationControllerForPresentedViewController:presentingViewController:sourceViewController:`:
'If you do not implement this method, or if your implementation of this method returns nil, the system uses a default presentation controller object. The default presentation controller does not add any views or content to the view hierarchy.'

Also, `needsRotationFixForModals` should be set to `YES` only if the iOS version is `7`.  iOS8 properly handles the view rotations properly and if the rotation fix is applied on iOS8, the rotations will be incorrect.