### PR TITLE
added popToViewController:usingTransition: method

### DIFF
--- a/Core/UINavigationController+STPTransitions.h
+++ b/Core/UINavigationController+STPTransitions.h
@@ -6,6 +6,10 @@
 
 - (void)pushViewController:(UIViewController *)viewController
            usingTransition:(STPTransition *)transition;
+
+- (void)popToViewController:(UIViewController*)viewController
+		   usingTransition:(STPTransition *)transition;
+
     
 - (UIViewController *)popViewControllerUsingTransition:(STPTransition *)transition;
 

--- a/Core/UINavigationController+STPTransitions.h
+++ b/Core/UINavigationController+STPTransitions.h
@@ -8,7 +8,7 @@
            usingTransition:(STPTransition *)transition;
 
 - (void)popToViewController:(UIViewController*)viewController
-		   usingTransition:(STPTransition *)transition;
+           usingTransition:(STPTransition *)transition;
 
     
 - (UIViewController *)popViewControllerUsingTransition:(STPTransition *)transition;

--- a/Core/UINavigationController+STPTransitions.m
+++ b/Core/UINavigationController+STPTransitions.m
@@ -14,6 +14,17 @@
     [self pushViewController:viewController animated:YES];
 }
 
+
+- (void)popToViewController:(UIViewController*)viewController usingTransition:(STPTransition *)transition {
+    if (![self.delegate isKindOfClass:STPTransitionCenter.class]) {
+        self.delegate = STPTransitionCenter.sharedInstance;
+    }
+    STPTransitionCenter *center = (STPTransitionCenter *)self.delegate;
+    [center setNextPopOrDismissTransition:transition fromViewController:self.topViewController];
+    [self popToViewController:viewController animated:YES];
+}
+
+
 - (UIViewController *)popViewControllerUsingTransition:(STPTransition *)transition {
     if (![self.delegate isKindOfClass:STPTransitionCenter.class]) {
         self.delegate = STPTransitionCenter.sharedInstance;

--- a/Core/UINavigationController+STPTransitions.m
+++ b/Core/UINavigationController+STPTransitions.m
@@ -15,7 +15,8 @@
 }
 
 
-- (void)popToViewController:(UIViewController*)viewController usingTransition:(STPTransition *)transition {
+- (void)popToViewController:(UIViewController*)viewController
+           usingTransition:(STPTransition *)transition {
     if (![self.delegate isKindOfClass:STPTransitionCenter.class]) {
         self.delegate = STPTransitionCenter.sharedInstance;
     }


### PR DESCRIPTION
Hi,

I have been using STPTransitions and it's awesome - but I needed to implement circular navigation in a project and ended up needing a popToViewController: usingTransition: method, so I added it to the UINavigationController category.
Here it is:)