### PR TITLE
Get correct frame for the toView in a transition.

### DIFF
--- a/Core/STPTransition.m
+++ b/Core/STPTransition.m
@@ -52,6 +52,7 @@
     UIViewController *toViewController = [transitionContext viewControllerForKey:UITransitionContextToViewControllerKey];
     self.fromViewController = fromViewController;
     self.toViewController = toViewController;
+    self.toViewController.view.frame = [transitionContext finalFrameForViewController:self.toViewController];
     UIView *containerView = [transitionContext containerView];
 
     void (^modalPresentationCompletionFix)(void);


### PR DESCRIPTION
In iOS 9, when the `view` of the view controller being transitioned to is not the full size of its container then it is incorrectly positioned. For example, in a navigation controller it will appear at origin `0, 0`, underneath the navigation bar, even if the bar is set to not be translucent.

This issue can be demonstrated by adding the following to the example project's `-[STPSecondViewController viewDidLoad]` and comparing the behaviour between iOS 8 and iOS 9:

```
self.navigationController.navigationBar.translucent = NO;
    self.view.frame = (CGRect){
        .origin = self.view.frame.origin,
        .size.width = self.view.frame.size.width,
        .size.height = self.view.frame.size.height / 2
    };
```

This change addresses the issue by asking the context for the correct final frame for the view, and setting it before it is added as a subview of its container.