### PR TITLE
Add post-transition View Controller hooks to View Controller category

### DIFF
--- a/Core/UIViewController+STPTransitions.h
+++ b/Core/UIViewController+STPTransitions.h
@@ -19,9 +19,13 @@
                      usingTransition:(STPTransition *)transition;
 
 // You can override these methods in your UIViewController subclass to react to a transition.
+
 // Outer view controller is either lower in the navigation stack, or the presenting controller.
 - (void)willPerformTransitionAsOuterViewController:(STPTransition *)transition;
+- (void)didPerformTransitionAsOuterViewController:(STPTransition *)transition;
+
 // Inner view controller is either higher in the navigation stack, or the presented controller.
 - (void)willPerformTransitionAsInnerViewController:(STPTransition *)transition;
+- (void)didPerformTransitionAsInnerViewController:(STPTransition *)transition;
 
 @end

--- a/Core/UIViewController+STPTransitions.m
+++ b/Core/UIViewController+STPTransitions.m
@@ -154,6 +154,8 @@
         if (transition.onCompletion) {
             transition.onCompletion(transition, YES);
         }
+        [fromViewController didPerformTransitionAsOuterViewController:transition];
+        [toViewController didPerformTransitionAsInnerViewController:transition];
     };
 
     if (transition) {
@@ -172,8 +174,10 @@
 }
 
 - (void)willPerformTransitionAsInnerViewController:(STPTransition *)transition {}
+- (void)didPerformTransitionAsInnerViewController:(STPTransition *)transition {}
 
 - (void)willPerformTransitionAsOuterViewController:(STPTransition *)transition {}
+- (void)didPerformTransitionAsOuterViewController:(STPTransition *)transition {}
 
 - (void)willAnimateRotationToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation
                                          duration:(NSTimeInterval)duration {


### PR DESCRIPTION
`UIViewController+STPTransitions` currently provides pre-transition hooks, which are extremely useful. 

Post transition hooks will also allow users to perform any additional cleanup, or further manage View Controller state, after the transition has taken place.

View controllers lifecycle state methods, e.g. `viewDidLoad` and `viewDidAppear` are unreliable proxies as we may have a transition that fully loads the ViewControllers view (activating these methods) but the transition hasn't actually taken place on screen yet. 

These new category methods allow much more fine grained access to the ViewControllers views lifecycle during a transition.